### PR TITLE
fix target_keys specification

### DIFF
--- a/hub-config/tasks.json
+++ b/hub-config/tasks.json
@@ -131,9 +131,7 @@
                             "target_name": "week ahead weekly influenza hospitalization rate category",
                             "target_units": "rate per 100,000 population",
                             "target_keys": {
-                                "target": [
-                                    "wk flu hosp rate category"
-                                ]
+                                "target": "wk flu hosp rate category"
                             },
                             "target_type": "ordinal",
                             "description": "This target represents a categorical severity level for rate of new hospitalizations per week for the week ending [horizon] weeks after the reference_date, on target_end_date.",
@@ -278,9 +276,7 @@
                             "target_name": "week ahead weekly influenza hospitalization rate",
                             "target_units": "rate per 100,000 population",
                             "target_keys": {
-                                "target": [
-                                    "wk flu hosp rate"
-                                ]
+                                "target": "wk flu hosp rate"
                             },
                             "target_type": "continuous",
                             "description": "This target is the weekly rate of new hospitalizations per 100k population for the week ending [horizon] weeks after the reference_date, on target_end_date.",
@@ -466,9 +462,7 @@
                             "target_name": "incident influenza hospitalizations",
                             "target_units": "count",
                             "target_keys": {
-                                "target": [
-                                    "wk inc flu hosp"
-                                ]
+                                "target": "wk inc flu hosp"
                             },
                             "target_type": "continuous",
                             "description": "This target represents the count of new hospitalizations in the week ending on the date [horizon] weeks after the reference_date, on the target_end_date.",


### PR DESCRIPTION
values within `target_keys` were previously an array, which was incorrect (compare to the [examples in the schema](https://github.com/hubverse-org/schemas/blob/2148965efadac7c8199cc670ec84db711fd58f1f/v3.0.1/tasks-schema.json#L1251-L1271)).  Now they are just strings.

With this update, validations pass:
```
> val_results <- hubAdmin::validate_hub_config()
✔ Hub correctly configured! 
admin.json, tasks.json and model-metadata-schema.json all valid.
```

I have reported the fact that the validation of this config file previously passed incorrectly [here](https://github.com/hubverse-org/schemas/issues/97).

