### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/model-metadata/README.md
+++ b/model-metadata/README.md
@@ -13,9 +13,9 @@ folder with a template that submitting teams can copy and update for their
 own models. Because some model metadata fields may be hub-specific, creators 
 of the hub are encouraged to create their template by:
 
-- adding the [Hubverse template model metadata file](https://hubverse.io/en/latest/user-guide/model-metadata.html#template-metadata-schema-file) to `model-metadata` 
+- adding the [Hubverse template model metadata file](https://docs.hubverse.io/en/latest/user-guide/model-metadata.html#template-metadata-schema-file) to `model-metadata` 
 - modifying the template model metadata file to include any hub-specific fields
-- ensuring that the above changes are consistent with [Hubverse model metadata guidelines](https://hubverse.io/en/latest/format/model-metadata.html).
+- ensuring that the above changes are consistent with [Hubverse model metadata guidelines](https://docs.hubverse.io/en/latest/format/model-metadata.html).
 
 
 The instructions below provide detail about the [data

--- a/model-output/README.md
+++ b/model-output/README.md
@@ -1,3 +1,3 @@
 # Model outputs folder
 
-This folder should contain a set of subdirectories, one for each model, that contains submitted model output files for that model. The structure of the directories and their contents should follow [the model output guidelines in our documentation](https://hubverse.io/en/latest/user-guide/model-output.html).
+This folder should contain a set of subdirectories, one for each model, that contains submitted model output files for that model. The structure of the directories and their contents should follow [the model output guidelines in our documentation](https://docs.hubverse.io/en/latest/user-guide/model-output.html).


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.